### PR TITLE
Change package main file to point at es2015 file

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "ray-input",
   "version": "0.1.0",
   "description": "Cross platform VR input capabilities. For desktop, mobile, Cardboard, Daydream and Vive.",
-  "main": "build/ray.js",
+  "main": "src/ray-input.js",
   "scripts": {
     "build": "rollup -c",
     "watch": "watchify -vdt [ babelify --presets [ es2015 ] ] src/example/main.js -o build/example.js",
@@ -23,5 +23,6 @@
     "babelify": "^7.3.0",
     "rollup": "^0.36.1",
     "rollup-plugin-uglify": "^1.0.1"
-  }
+  },
+  "browserify": { "transform": ["babelify"] }
 }


### PR DESCRIPTION
The main entrypoint is only used by ES2015 compatible setups. This way when developing in ES2015 you are not including a transpiled ES5 file , but instead directly include the ES2015 file. 

The ES5 file is still build and can be included manually in a script tag. 
