### PR TITLE
Implement isTouchActive and deactivation of ray-renderer

### DIFF
--- a/src/ray-controller.js
+++ b/src/ray-controller.js
@@ -47,6 +47,9 @@ export default class RayController extends EventEmitter {
     window.addEventListener('touchmove', this.onTouchMove_.bind(this));
     window.addEventListener('touchend', this.onTouchEnd_.bind(this));
 
+    // Listen to mouse events, set to true on first touch event
+    this.isTouchSupported = false;
+
     // The position of the pointer.
     this.pointer = new THREE.Vector2();
     // The previous position of the pointer.
@@ -57,6 +60,8 @@ export default class RayController extends EventEmitter {
     this.dragDistance = 0;
     // Are we dragging or not.
     this.isDragging = false;
+    // Is pointer active or not.
+    this.isTouchActive = false;
 
     // Gamepad events.
     this.gamepad = null;
@@ -112,6 +117,14 @@ export default class RayController extends EventEmitter {
     return gamepad.pose;
   }
 
+  /**
+   * Get if there is an active touch event going on.
+   * Only relevant on touch devices
+   */
+  getIsTouchActive() {
+    return this.isTouchActive;
+  }
+
   setSize(size) {
     this.size = size;
   }
@@ -148,26 +161,34 @@ export default class RayController extends EventEmitter {
   }
 
   onMouseDown_(e) {
-    this.startDragging_(e);
-    this.emit('action');
+    if(!this.isTouchSupported) {
+      this.startDragging_(e);
+      this.emit('action');
+    }
   }
 
   onMouseMove_(e) {
-    this.updatePointer_(e);
-    this.updateDragDistance_();
-
-    this.emit('pointermove', this.pointerNdc);
+    if(!this.isTouchSupported) {
+      this.updatePointer_(e);
+      this.updateDragDistance_();
+      this.emit('pointermove', this.pointerNdc);
+    }
   }
 
   onMouseUp_(e) {
-    this.endDragging_();
+    if(!this.isTouchSupported) {
+      this.endDragging_();
+    }
   }
 
   onTouchStart_(e) {
+    this.isTouchSupported = true;
+
     var t = e.touches[0];
     this.startDragging_(t);
     this.updateTouchPointer_(e);
 
+    this.isTouchActive = true;
     this.emit('pointermove', this.pointerNdc);
     this.emit('action');
   }
@@ -178,6 +199,7 @@ export default class RayController extends EventEmitter {
   }
 
   onTouchEnd_(e) {
+    this.isTouchActive = false;
     this.endDragging_();
   }
 

--- a/src/ray-input.js
+++ b/src/ray-input.js
@@ -69,6 +69,9 @@ export default class RayInput extends EventEmitter {
         // Hide the ray and reticle.
         this.renderer.setRayVisibility(false);
         this.renderer.setReticleVisibility(false);
+
+        // In mouse mode ray renderer is always active 
+        this.renderer.setActive(true);
         break;
 
       case InteractionModes.TOUCH:
@@ -76,9 +79,12 @@ export default class RayInput extends EventEmitter {
         // hide the reticle.
         this.renderer.setPointer(this.pointerNdc);
 
-        // Hide the ray and show the reticle.
+        // Hide the ray and the reticle.
         this.renderer.setRayVisibility(false);
-        this.renderer.setReticleVisibility(true);
+        this.renderer.setReticleVisibility(false);
+
+        // In touch mode the ray renderer is only active on touch
+        this.renderer.setActive(this.controller.getIsTouchActive());
         break;
 
       case InteractionModes.VR_0DOF:
@@ -89,6 +95,9 @@ export default class RayInput extends EventEmitter {
         // Reticle only.
         this.renderer.setRayVisibility(false);
         this.renderer.setReticleVisibility(true);
+
+        // Ray renderer always active
+        this.renderer.setActive(true);
         break;
 
       case InteractionModes.VR_3DOF:
@@ -125,6 +134,9 @@ export default class RayInput extends EventEmitter {
         // Show ray and reticle.
         this.renderer.setRayVisibility(true);
         this.renderer.setReticleVisibility(true);
+
+        // Ray renderer always active
+        this.renderer.setActive(true);
         break;
 
       case InteractionModes.VR_6DOF:
@@ -146,6 +158,9 @@ export default class RayInput extends EventEmitter {
         // Show ray and reticle.
         this.renderer.setRayVisibility(true);
         this.renderer.setReticleVisibility(true);
+        
+        // Ray renderer always active
+        this.renderer.setActive(true);
         break;
 
       default:


### PR DESCRIPTION
Currently in magic window the ray stays at the last position pressed, resulting in selection of meshes when there is no touch.

This PR does:
- Adds `getIsTouchActive` on ray-controller, is true when there is a touch event happening
- Deactivates the ray renderer on touchend, and deselects any selected meshes. 
- Added check that filters out mouse events if there are touch events (since mousemove is called on mobile and confuses the message)
