### PR TITLE
Allow specifying custom element to bind to

### DIFF
--- a/src/ray-controller.js
+++ b/src/ray-controller.js
@@ -33,19 +33,19 @@ const DRAG_DISTANCE_PX = 10;
  *    pointermove(2D position): The pointer is moved (mouse or touch).
  */
 export default class RayController extends EventEmitter {
-  constructor(renderer) {
+  constructor(element) {
     super();
-    this.renderer = renderer;
+    this.element = element;
 
     this.availableInteractions = {};
 
     // Handle interactions.
-    window.addEventListener('mousedown', this.onMouseDown_.bind(this));
-    window.addEventListener('mousemove', this.onMouseMove_.bind(this));
-    window.addEventListener('mouseup', this.onMouseUp_.bind(this));
-    window.addEventListener('touchstart', this.onTouchStart_.bind(this));
-    window.addEventListener('touchmove', this.onTouchMove_.bind(this));
-    window.addEventListener('touchend', this.onTouchEnd_.bind(this));
+    this.element.addEventListener('mousedown', this.onMouseDown_.bind(this));
+    this.element.addEventListener('mousemove', this.onMouseMove_.bind(this));
+    this.element.addEventListener('mouseup', this.onMouseUp_.bind(this));
+    this.element.addEventListener('touchstart', this.onTouchStart_.bind(this));
+    this.element.addEventListener('touchmove', this.onTouchMove_.bind(this));
+    this.element.addEventListener('touchend', this.onTouchEnd_.bind(this));
 
     // Listen to mouse events, set to true on first touch event.
     this.isTouchSupported = false;

--- a/src/ray-input.js
+++ b/src/ray-input.js
@@ -23,12 +23,13 @@ import InteractionModes from './ray-interaction-modes'
  * API wrapper for the input library.
  */
 export default class RayInput extends EventEmitter {
-  constructor(camera) {
+  constructor(camera, element) {
     super();
 
     this.camera = camera;
+    this.element = element || window;
     this.renderer = new RayRenderer(camera);
-    this.controller = new RayController();
+    this.controller = new RayController(element);
 
     // Arm model needed to transform controller orientation into proper pose.
     this.armModel = new OrientationArmModel();


### PR DESCRIPTION
- Vizor needs to specify a custom element to listen to instead of the entire window (ie. only listen to the WebGL canvas)
