### PR TITLE
Allow passing custom scene hierarchy to intersect

### DIFF
--- a/src/ray-input.js
+++ b/src/ray-input.js
@@ -57,7 +57,7 @@ export default class RayInput extends EventEmitter {
     delete this.handlers[object.id]
   }
 
-  update() {
+  update(meshes) {
     let lookAt = new THREE.Vector3(0, 0, -1);
     lookAt.applyQuaternion(this.camera.quaternion);
 
@@ -166,7 +166,7 @@ export default class RayInput extends EventEmitter {
       default:
         console.error('Unknown interaction mode.');
     }
-    this.renderer.update();
+    this.renderer.update(meshes);
     this.controller.update();
   }
 

--- a/src/ray-input.js
+++ b/src/ray-input.js
@@ -61,6 +61,8 @@ export default class RayInput extends EventEmitter {
     let lookAt = new THREE.Vector3(0, 0, -1);
     lookAt.applyQuaternion(this.camera.quaternion);
 
+    this.currentMeshes = meshes;
+
     let mode = this.controller.getInteractionMode();
     switch (mode) {
       case InteractionModes.MOUSE:
@@ -196,7 +198,7 @@ export default class RayInput extends EventEmitter {
     //console.log('onRayDown_');
 
     // Force the renderer to raycast.
-    this.renderer.update();
+    this.renderer.update(this.currentMeshes);
     let mesh = this.renderer.getSelectedMesh();
     this.emit('raydown', mesh);
 

--- a/src/ray-renderer.js
+++ b/src/ray-renderer.js
@@ -94,15 +94,28 @@ export default class RayRenderer extends EventEmitter {
     }
   }
 
-  update() {
+  update(meshes) {
     // Do the raycasting and issue various events as needed.
+    let intersects = this.raycaster.intersectObjects(meshes, true);
+    let intersectedMesh;
+
+    for (var i=0; i < intersects.length; i++) {
+      let obj = intersects[i].object;
+
+      // traverse the hierarchy backwards, to find a clickable mesh via a child
+      while (obj && !this.meshes[obj.id]) {
+        obj = obj.parent;
+      }
+
+      if (obj) {
+        intersectedMesh = obj.id;
+        break;
+      }
+    }
+
     for (let id in this.meshes) {
       let mesh = this.meshes[id];
-      let intersects = this.raycaster.intersectObject(mesh, true);
-      if (intersects.length > 1) {
-        console.warn('Unexpected: multiple meshes intersected.');
-      }
-      let isIntersected = (intersects.length > 0);
+      let isIntersected = (intersectedMesh === id);
       let isSelected = this.selected[id];
 
       // If it's newly selected, send rayover.

--- a/src/ray-renderer.js
+++ b/src/ray-renderer.js
@@ -115,7 +115,7 @@ export default class RayRenderer extends EventEmitter {
 
     for (let id in this.meshes) {
       let mesh = this.meshes[id];
-      let isIntersected = (intersectedMesh === id);
+      let isIntersected = (intersectedMesh === mesh.id);
       let isSelected = this.selected[id];
 
       // If it's newly selected, send rayover.


### PR DESCRIPTION
When switching between multiple scenes, add/remove can be very costly.
Also change the intersect handling to handle nested meshes.