### PR TITLE
Only cancel mouse events if the ray hit a mesh

### DIFF
--- a/src/ray-controller.js
+++ b/src/ray-controller.js
@@ -157,7 +157,7 @@ export default class RayController extends EventEmitter {
 
   onMouseDown_(e) {
     this.startDragging_(e);
-    this.emit('raydown');
+    this.emit('raydown', e);
   }
 
   onMouseMove_(e) {
@@ -167,7 +167,7 @@ export default class RayController extends EventEmitter {
   }
 
   onMouseUp_(e) {
-    this.endDragging_();
+    this.endDragging_(e);
   }
 
   onTouchStart_(e) {
@@ -177,10 +177,7 @@ export default class RayController extends EventEmitter {
     this.updateTouchPointer_(e);
 
     this.emit('pointermove', this.pointerNdc);
-    this.emit('raydown');
-
-    // Prevent synthetic mouse event from being created.
-    e.preventDefault();
+    this.emit('raydown', e);
   }
 
   onTouchMove_(e) {
@@ -192,10 +189,8 @@ export default class RayController extends EventEmitter {
   }
 
   onTouchEnd_(e) {
-    this.endDragging_();
+    this.endDragging_(e);
 
-    // Prevent synthetic mouse event from being created.
-    e.preventDefault();
     this.isTouchActive = false;
   }
 
@@ -222,8 +217,6 @@ export default class RayController extends EventEmitter {
       this.dragDistance += distance;
       this.lastPointer.copy(this.pointer);
 
-
-      //console.log('dragDistance', this.dragDistance);
       if (this.dragDistance > DRAG_DISTANCE_PX) {
         this.emit('raycancel');
         this.isDragging = false;
@@ -233,12 +226,13 @@ export default class RayController extends EventEmitter {
 
   startDragging_(e) {
     this.isDragging = true;
+    this.dragDistance = 0;
     this.lastPointer.set(e.clientX, e.clientY);
   }
 
-  endDragging_() {
+  endDragging_(e) {
     if (this.dragDistance < DRAG_DISTANCE_PX) {
-      this.emit('rayup');
+      this.emit('rayup', e);
     }
     this.dragDistance = 0;
     this.isDragging = false;

--- a/src/ray-input.js
+++ b/src/ray-input.js
@@ -198,15 +198,22 @@ export default class RayInput extends EventEmitter {
     // Force the renderer to raycast.
     this.renderer.update();
     let mesh = this.renderer.getSelectedMesh();
+
+    this.rayDownMesh = mesh;
     this.emit('raydown', mesh);
 
     this.renderer.setActive(true);
   }
 
   onRayUp_(e) {
-    //console.log('onRayUp_');
-    let mesh = this.renderer.getSelectedMesh();
-    this.emit('rayup', mesh);
+    // console.log('onRayUp_', e && this.rayDownMesh);
+
+    if (e && this.rayDownMesh) {
+        e.preventDefault();
+    }
+
+    this.emit('rayup', this.rayDownMesh);
+    this.rayDownMesh = null;
 
     this.renderer.setActive(false);
   }


### PR DESCRIPTION
Don't cancel mouse/touch events unless the ray has hit something. 

- also fixes issue with missing rayup if mesh disappears on raydown
- also fixes issue with mouse dragging calculated incorrectly