### PR TITLE
on raydown, rerun the update loop in order to account for new pointerNdc

### DIFF
--- a/src/ray-input.js
+++ b/src/ray-input.js
@@ -196,7 +196,7 @@ export default class RayInput extends EventEmitter {
     //console.log('onRayDown_');
 
     // Force the renderer to raycast.
-    this.renderer.update();
+    this.update();
     let mesh = this.renderer.getSelectedMesh();
     this.emit('raydown', mesh);
 

--- a/src/ray-input.js
+++ b/src/ray-input.js
@@ -196,11 +196,16 @@ export default class RayInput extends EventEmitter {
     //console.log('onRayDown_');
 
     // Force the renderer to raycast.
-    this.update();
-    let mesh = this.renderer.getSelectedMesh();
-    this.emit('raydown', mesh);
+    // Do this in the next tick to avoid an infinite loop.
+    // A better way of doing this would be to handle 
+    // the raydown state in the update loop.
+    setTimeout(() => {
+      this.update();
+      let mesh = this.renderer.getSelectedMesh();
+      this.emit('raydown', mesh);
 
-    this.renderer.setActive(true);
+      this.renderer.setActive(true);
+    }, 0)
   }
 
   onRayUp_(e) {


### PR DESCRIPTION
this fixes an issue where the pointerNdc wasn't being taken into account on touchstart.

a better solution would be to move ray state handling into the update loop (instead of events), but this works for now.